### PR TITLE
chore: remove indent rule from eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,6 @@ export default tseslint.config(
 		},
 		rules: {
 			...reactHooks.configs.recommended.rules,
-			'indent': ['error', 'tab'],
 			'linebreak-style': ['error', 'unix'],
 			'quotes': ['error', 'single'],
 			'semi': ['error', 'never'],


### PR DESCRIPTION
1. Remove the following indent-related rules from our ESLint configuration:
`'indent': ['error', 'tab']`
2. Ensure our EditorConfig (.editorconfig) file is properly configured for indentation.
3. Verify that our Prettier configuration aligns with our desired indentation style.

Closes #89 